### PR TITLE
住所登録フォームの都道府県登録にactive_hush適用

### DIFF
--- a/app/assets/stylesheets/modules/_user-sign.scss
+++ b/app/assets/stylesheets/modules/_user-sign.scss
@@ -199,3 +199,7 @@
     }
   }
 }
+
+#address_prefecture_id {
+  @include user-sign-form;
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -68,6 +68,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def address_params
-    params.require(:address).permit(:delively_last_name, :delively_first_name, :delively_last_name_kana, :delively_first_name_kana, :postcode, :prefecture, :city, :block, :building, :phone_number)
+    params.require(:address).permit(:delively_last_name, :delively_first_name, :delively_last_name_kana, :delively_first_name_kana, :postcode, :prefecture_id, :city, :block, :building, :phone_number)
   end
 end

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -41,7 +41,7 @@
         = f.label :都道府県
         %a.user-sign__form__field__necessity 必須
         %br/
-        = f.text_field :prefecture, placeholder: "例) 大阪府", class: "user-sign__form__field__text-form"
+        = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "--"
       .user-sign__form__field
         = f.label :市町村
         %a.user-sign__form__field__necessity 必須


### PR DESCRIPTION
# WHAT
active_hushを用いた都道府県入力フォームに変更しました。
# WHY
操作性を少しでも良くする為と、入力ミスを防ぐ為。