### PR TITLE
ユーザマイページの更新

### DIFF
--- a/app/assets/stylesheets/modules/_user-show.scss
+++ b/app/assets/stylesheets/modules/_user-show.scss
@@ -50,6 +50,12 @@
           &__name {
             margin-bottom: 0;
           }
+          &--sold {
+            color: red;
+          }
+          &--sale {
+            color: $main-color;
+          }
         }
         &__next {
           width: 10%;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,8 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @products = Product.where(seller_id: current_user.id)
+    @images = Image.find(@products.ids)
   end
 
   def logout

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -23,7 +23,7 @@
               %span.user-show__products__link__selling__info--sold
                 売却済
             - else
-              %span.user-show__products__link__selling__info__status--sale
+              %span.user-show__products__link__selling__info--sale
                 出品中
           .user-show__products__link__selling__next
             %span

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -5,22 +5,28 @@
 
   .user-show__products
     %h2 出品した商品
-    = link_to root_path, class: "user-show__products__link" do
-      .user-show__products__link__selling
-        .user-show__products__link__selling__img
-          = image_tag "https://picsum.photos/200/200", size: "60x60"
-        .user-show__products__link__selling__info
-          %p.user-show__products__link__selling__info__name 商品の名前
-          %span.user-show__products__link__selling__info__heart
-          = icon("far", "heart")
-          1
-          %span.user-show__products__link__selling__info__comment
-          = icon("far", "comment")
-          1
-          %span.user-show__products__link__selling__info__status
-          出品中
-        .user-show__products__link__selling__next
-          %span
-          = icon("fa", "angle-right")
+    - @products.zip(@images).each do |product, image|
+      = link_to product_path(product.id), class: "user-show__products__link" do
+        .user-show__products__link__selling
+          .user-show__products__link__selling__img
+            = image_tag image.src.url, size: "60x60"
+          .user-show__products__link__selling__info
+            %p.user-show__products__link__selling__info__name
+              = product.name
+            %span.user-show__products__link__selling__info__heart
+            = icon("far", "heart")
+            0
+            %span.user-show__products__link__selling__info__comment
+            = icon("far", "comment")
+            0
+            - if product.buyer_id.present?
+              %span.user-show__products__link__selling__info--sold
+                売却済
+            - else
+              %span.user-show__products__link__selling__info__status--sale
+                出品中
+          .user-show__products__link__selling__next
+            %span
+            = icon("fa", "angle-right")
 
 = render partial: "products/footer"


### PR DESCRIPTION
# What
- ユーザーマイページで商品の一覧表示(each文)
- 出品中、売却済みでテキストカラーの変更
- 商品一覧から商品詳細ページにリンク

# Why
ユーザーマイページから出品した商品の一覧を確認し、商品の管理をしやすくするため。
<img width="1280" alt="出品一覧" src="https://user-images.githubusercontent.com/61184424/84375329-5c8b9480-ac1a-11ea-864c-2601337c9388.png">
