### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -38,11 +38,11 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    if current_user.id == @product.seller_id
+    if current_user.id == @product.seller_id && @product.destroy
       @product.destroy
       redirect_to root_path, alert: "商品を削除しました"
     else
-      render :show
+      render :show, alert: "商品削除に失敗しました"
     end
   end
   

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -36,8 +36,12 @@ class ProductsController < ApplicationController
       render :edit
     end
   end
-  
 
+  def destroy
+    @product.destroy
+    redirect_to root_path, alert: "商品を削除しました"
+  end
+  
   private
   def product_params
     params.require(:product).permit(:name, :content, :bland_name, :price, :prefecture_id, :product_status_id, :delively_days_id , :delively_cost_id, :category_id, :delively_method_id, images_attributes: [:src, :_destroy, :id]).merge(seller_id: current_user.id)

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -38,8 +38,12 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    @product.destroy
-    redirect_to root_path, alert: "商品を削除しました"
+    if current_user.id == @product.seller_id
+      @product.destroy
+      redirect_to root_path, alert: "商品を削除しました"
+    else
+      render :show
+    end
   end
   
   private

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -39,7 +39,6 @@ class ProductsController < ApplicationController
 
   def destroy
     if current_user.id == @product.seller_id && @product.destroy
-      @product.destroy
       redirect_to root_path, alert: "商品を削除しました"
     else
       render :show, alert: "商品削除に失敗しました"

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -15,7 +15,7 @@ class Product < ApplicationRecord
   belongs_to_active_hash :delively_days
   belongs_to_active_hash :delively_method
  
-  has_many :images
+  has_many :images, dependent: :destroy
 
 # validation
   accepts_nested_attributes_for :images, allow_destroy: true


### PR DESCRIPTION
# What
出品商品削除機能の実装
- 商品詳細画面から出品しているユーザのみ削除が可能
- `has_many :images, dependent: :destroy`にて、商品に紐づいている画像も同時に削除できるように実装

# Why
投稿した商品を削除できるようにして管理しやすくするため。


![delete action](https://user-images.githubusercontent.com/61184424/84494934-47c80300-ace5-11ea-967e-403e9c6e8acd.gif)

<img width="641" alt="before delete" src="https://user-images.githubusercontent.com/61184424/84494775-06cfee80-ace5-11ea-903f-9738bca4d226.png">

<img width="637" alt="after delete" src="https://user-images.githubusercontent.com/61184424/84494784-09324880-ace5-11ea-858c-8624bc5f5edf.png">
