### PR TITLE
ユーザーマイページと商品詳細ページの修正

### DIFF
--- a/app/assets/javascripts/product-show.js
+++ b/app/assets/javascripts/product-show.js
@@ -1,5 +1,5 @@
 $(function() {
-  $(".product-show__content__image__list img").click(function() {
+  $(".product-show__content__image__list img").mouseover(function() {
     $(".product-show__content__image__main").attr("src", $(this).attr("src"));
     return false;
   });

--- a/app/assets/stylesheets/modules/_user-show.scss
+++ b/app/assets/stylesheets/modules/_user-show.scss
@@ -42,6 +42,10 @@
           width: 15%;
           text-align: center;
           line-height: 80px;
+          img {
+            width: 60px;
+            height: 60px;
+          }
         }
         
         &__info {

--- a/app/assets/stylesheets/modules/show.scss
+++ b/app/assets/stylesheets/modules/show.scss
@@ -300,13 +300,17 @@
   // ------------------------------------
   &__links {
     list-style: none;
-    display: flex;
-    justify-content: space-between;
     margin-bottom: 32px;
     color: $main-color;
+    &__clearfix::after {
+      content: "";
+      clear: both;
+      display: block;
+    }
     &__prev {
       @include product-show_links;
       cursor: pointer;
+      float: left;
       &:before {
         @include product-show_font-awesome-5_solid;
         content: '\f104';
@@ -317,6 +321,7 @@
     &__next {
       color: $main-color;
       text-decoration: none;
+      float: right;
       cursor: pointer;
       &:after {
         @include product-show_font-awesome-5_solid;
@@ -324,6 +329,7 @@
         margin-left: 4px;
         font-size: inherit;
       }
+
     }
   }
   &__more-items a {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,6 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @products = Product.where(seller_id: current_user.id)
-    @images = Image.find(@products.ids)
   end
 
   def logout

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -14,13 +14,22 @@ class Product < ApplicationRecord
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :delively_days
   belongs_to_active_hash :delively_method
- 
+
   has_many :images, dependent: :destroy
 
-# validation
+  # validation
   accepts_nested_attributes_for :images, allow_destroy: true
   validates :name, length: { maximum: 40 }, presence: true
   validates :content, length: { maximum: 1000 }, presence: true
   validates :price, numericality: { :greater_than_or_equal_to => 300, :less_than_or_equal_to => 9999999 }, presence: true
+
+  # 前後のレコードを取得するメソッド
+  def previous
+    Product.order('created_at desc, id desc').where('created_at <= ? and id < ?', created_at, id).first
+  end
+
+  def next
+    Product.order('created_at desc, id desc').where('created_at >= ? and id > ?', created_at, id).reverse.first
+  end
 
 end

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -53,7 +53,8 @@
           %button 売り切れました
 
     .product-show__content__explanation
-      %p 
+      %p
+        = @product.content
     .product-show__content__info
       %table.product-show__content__info__table
         %tbody

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -135,13 +135,16 @@
         - else
           %button.product-show__comment__sold-btn 売り切れのためコメントできません
 
-  %ul.product-show__links
-    %li
-      = link_to "前の商品", product_path(@product.id - 1), class: "product-show__links__prev"
-    %li
-      = link_to "後ろの商品", product_path(@product.id + 1), class: "product-show__links__next"
+  %ul.product-show__links.product-show__links__clearfix
+    - if @product.previous.present?
+      %li
+        = link_to "前の商品", product_path(@product.previous), class: "product-show__links__prev"
+    - if @product.next.present?
+      %li
+        = link_to "後ろの商品", product_path(@product.next), class: "product-show__links__next"
 
   .product-show__more-items
-    = link_to "ベビー・キッズをもっと見る", product_path
+    = link_to product_path do
+      = "#{@product.category.parent.parent.name}をもっと見る"
 
 = render partial: "products/footer"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -6,17 +6,19 @@
       = link_to "FURIMA", root_path
     %li
       = icon("fa", "angle-right")
-    -# 【Todo】カテゴリー先にリンク
     %li
-      = link_to "ベビーキッズ", product_path
-    %li
-      = icon("fa", "angle-right")
-    %li
-      = link_to "ベビー服(男女兼用) ~95cm", product_path
+      = link_to product_path do
+        = @product.category.parent.parent.name
     %li
       = icon("fa", "angle-right")
     %li
-      = link_to "アウター", product_path
+      = link_to product_path do
+        = @product.category.parent.name
+    %li
+      = icon("fa", "angle-right")
+    %li
+      = link_to product_path do
+        = @product.category.name
     %li
       = icon("fa", "angle-right")
     %li.product-breadcrumb__list--this
@@ -66,6 +68,10 @@
             %th カテゴリー
             %td
               = link_to product_path, class: "product-show__content__info__table__category" do
+                = @product.category.parent.parent.name
+                %br
+                = @product.category.parent.name
+                %br
                 = @product.category.name
           %tr
             %th ブランド

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -5,11 +5,11 @@
 
   .user-show__products
     %h2 出品した商品
-    - @products.zip(@images).each do |product, image|
+    - @products.each do |product|
       = link_to product_path(product.id), class: "user-show__products__link" do
         .user-show__products__link__selling
           .user-show__products__link__selling__img
-            = image_tag image.src.url, size: "60x60"
+            = image_tag product.images.first.src.url
           .user-show__products__link__selling__info
             %p.user-show__products__link__selling__info__name
               = product.name


### PR DESCRIPTION
#  What
#### 出品後にユーザーマイページに行けないエラーを修正
データベースから画像データを取得できないことが原因のため、ビューファイルを下記修正にて1つの商品につき最初の1枚だけの画像データをeach文で取得
`= image_tag product.images.first.src.url`

#### 商品詳細ページの修正
- 商品の説明文が表示されていない問題を修正
- ユーザビリティ向上のためにマウスホバーで画像が切り替わるように修正
- Ancestryを利用して登録されているカテゴリデータを表示できるように修正
- 画面下部にて、前後の商品に移動できるように修正（モデルファイルにメソッド追記）

#  Why
エラーが発生しないようにするため。商品詳細ページを見やすくするため。

![fix user-images](https://user-images.githubusercontent.com/61184424/84502916-2de1ec80-acf4-11ea-8e51-cc26739bad54.gif)