### PR TITLE
パンくずリストとカテゴリー一覧ページの作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,8 @@
 
 @import "./modules/credit-new.scss";
 
+@import "./modules/category.scss";
+
 @import "modules/header";
 @import "modules/footer";
 

--- a/app/assets/stylesheets/modules/_category.scss
+++ b/app/assets/stylesheets/modules/_category.scss
@@ -1,0 +1,99 @@
+.categories-breadcrumb {
+  width: 100%;
+  height: 56px;
+  line-height: 56px;
+  border-top: 1px solid #eee;
+  padding: 0 120px;
+  background-color: #fff;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, .16);
+  &__list {
+    display: flex;
+    li {
+      font-size: 0.9rem;
+      margin: 0 6px;
+      a {
+        color: #000;
+        text-decoration: none;
+        &:hover {
+          color: $main-color;
+        }
+      }
+    }
+    &--this {
+      font-weight: bold;
+    }
+  }
+}
+
+.categories {
+  width: 700px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 48px 0;
+  &__top {
+    font-size: 0.9rem;
+  }
+  &__ancestors {
+    display: flex;
+    flex-wrap: wrap;
+    width: 600px;
+    margin-bottom: 16px;
+    &__name {
+      display: block;
+      height: 40px;
+      line-height: 40px;
+      background-color: #fff;
+      padding: 0 24px;
+      margin: 5px;
+      text-decoration: none;
+      color: #000;
+      border-radius: 4px;
+      box-shadow: 1px 1px 1px 1px rgba(14,14,14,0.0580392);
+      &:hover {
+        background-color: $main-color;
+        color: #fff;
+      }
+    }
+  }
+  &__sub {
+    background-color: $main-color;
+    font-size: 1rem;
+    font-weight: bold;
+    border-radius: 4px;
+    padding: 6px 30px;
+    a {
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+  &__list {
+    background-color: #fff;
+    padding: 24px;
+    font-size: 0.9rem;
+    margin-bottom: 32px;
+    &__all {
+      display: block;
+      margin: 0 0 8px;
+      text-decoration: none;
+      color: blue;
+    }
+    h4 {
+      margin: 0;
+    }
+    &__box {
+      padding: 8px 16px;
+      display: flex;
+      flex-wrap: wrap;
+      &__name {
+        display: block;
+        width: 300px;
+        margin: 0 0 8px;
+        text-decoration: none;
+        color: blue;
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/show.scss
+++ b/app/assets/stylesheets/modules/show.scss
@@ -2,8 +2,8 @@
 // ------------------------------------
 .product-breadcrumb {
   width: 100%;
-  height: 72px;
-  line-height: 72px;
+  height: 56px;
+  line-height: 56px;
   border-top: 1px solid #eee;
   padding: 0 120px;
   background-color: #fff;
@@ -11,7 +11,7 @@
   &__list {
     display: flex;
     li {
-      font-size: 1.2rem;
+      font-size: 0.9rem;
       margin: 0 6px;
       a {
         color: #000;
@@ -122,12 +122,10 @@
     }
     &__soldout {
       text-decoration: none;
-      button {
-        @include product-show_btn;
-        width: 100%;
-        background-color: #AAAAAA;
-        cursor: not-allowed;
-      }
+      @include product-show_btn;
+      width: 100%;
+      background-color: #AAAAAA;
+      cursor: not-allowed;
     }
     &__explanation {
       line-height: 1.7rem;

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,5 @@
+class CategoriesController < ApplicationController
+  def index
+    @ancestries = Category.all.order("ancestry ASC").order("id ASC").limit(13)
+  end
+end

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,0 +1,35 @@
+= render partial: "products/header"
+
+.categories-breadcrumb
+  %ul.categories-breadcrumb__list
+    %li
+      = link_to "FURIMA", root_path
+    %li
+      = icon("fa", "angle-right")
+    %li
+      = link_to categories_path do
+        カテゴリ一覧
+
+.categories
+  .categories__top
+    %h2 カテゴリー一覧
+  .categories__ancestors
+    - @ancestries.each do |ancestry|
+      = link_to({ anchor: "#{ancestry.name}" }, class: "categories__ancestors__name") do
+        = ancestry.name
+  - @ancestries.each do |ancestry|
+    .categories__sub
+      = link_to categories_path, id: "#{ancestry.name}" do
+        = ancestry.name
+    .categories__list
+      = link_to categories_path, class: "categories__list__all" do
+        すべて
+      - ancestry.children.each do |child|
+        %h4
+          = child.name
+        .categories__list__box
+          - child.children.each do |grandchild|
+            = link_to categories_path, class: "categories__list__box__name" do
+              = grandchild.name
+
+= render partial: "products/footer"

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -8,7 +8,7 @@
   .header__list
     %ul.header__list-left
       %li 
-        = link_to "カテゴリー","#",class:"header__list-left-link"
+        = link_to "カテゴリー",categories_path,class:"header__list-left-link"
       %li 
         = link_to "ブランド","#",class:"header__list-left-link"
     %ul.header__list-right

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -7,17 +7,17 @@
     %li
       = icon("fa", "angle-right")
     %li
-      = link_to product_path do
+      = link_to categories_path(anchor: "#{@product.category.parent.parent.name}") do
         = @product.category.parent.parent.name
     %li
       = icon("fa", "angle-right")
     %li
-      = link_to product_path do
+      = link_to categories_path(anchor: "#{@product.category.parent.parent.name}") do
         = @product.category.parent.name
     %li
       = icon("fa", "angle-right")
     %li
-      = link_to product_path do
+      = link_to categories_path(anchor: "#{@product.category.parent.parent.name}") do
         = @product.category.name
     %li
       = icon("fa", "angle-right")
@@ -51,8 +51,7 @@
         = link_to purchase_path(@product.id), class: "product-show__content__purchace" do
           %button 購入画面に進む
       - else
-        = link_to product_path, class: "product-show__content__soldout" do
-          %button 売り切れました
+        .product-show__content__soldout 売り切れました
 
     .product-show__content__explanation
       %p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,4 +36,6 @@ Rails.application.routes.draw do
       get 'done', to: 'purchase#done'
     end
   end
+
+  resources :categories, only: :index
 end


### PR DESCRIPTION
# What
#### カテゴリー一覧ページの作成
- Ancestryによって追加したデータベースを一覧表示
- 各カテゴリの一番上の親要素にのみページ内リンクを設定
※Ancestryの子要素1つ1つにはリンクは未設定

#### パンくずリスト作成
- 商品詳細ページの上部にカテゴリ階層順にリンクで表示
- リンクは親カテゴリに対応する、カテゴリー一覧ページのページ内リンクへ繋げている

# Why
ユーザーが商品詳細ページから商品のカテゴリーを確認し、移動できるようにするため。

<img width="1080" alt="category index" src="https://user-images.githubusercontent.com/61184424/84740508-7a754280-afe8-11ea-91b5-e83d1013e18a.png">
<img width="1280" alt="Breadcrumb" src="https://user-images.githubusercontent.com/61184424/84740769-f53e5d80-afe8-11ea-8655-96a2be5e743c.png">