### PR TITLE
他人の商品の編集画面へURLを直打ちしても飛べないようにする。

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,7 @@
 class ProductsController < ApplicationController
-  before_action :set_product, except: [:index, :new, :edit, :create,:get_category_children,:get_category_grandchildren]
+  before_action :set_product, except: [:index, :new, :create,:get_category_children,:get_category_grandchildren]
   before_action :move_to_index, except: [:index, :show]
+  before_action :refuse_to_edit, only: :edit
 
   def index
     @products = Product.includes(:images).order('created_at DESC')
@@ -73,4 +74,10 @@ end
   def move_to_index
     redirect_to user_session_path unless user_signed_in?
   end
+
+  def refuse_to_edit
+    if current_user.id != @product.id
+      redirect_to root_path
+    end
+  end 
 end


### PR DESCRIPTION
# WHAT
- 直接URLを入力すると他人の商人の編集画面へ飛べていたのを、root_pathへ返すようにしました。
- また、商品出品ページが完成してから商品編集ページも完成するのですが、浦様との余計なコンフリクトを起こさない為に、本プルリクエストでは一切編集のビューファイルは触っていませんので、未だに本番環境では商品編集ページに飛べないと思いますがご了承下さい。
# WHY
他人の商品の編集ができると機能的に大変だから。