### PR TITLE
routes.rbの修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,6 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :searches,　only:　:index
+  resources :searches, only: :index
   resources :categories, only: :index
 end


### PR DESCRIPTION
# WHAT
前回のプルリクエストのコンフリクト解消の際、記述を周りに合わせようとした所、全角スペースを使ってしまったためmasterブランチ内でroutingエラーが発生しているのを修正した。

# WHY
masterブランチ内でエラーが発生しているため