### PR TITLE
商品検索機能Lv１　実装

### DIFF
--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -155,5 +155,9 @@
         }
       }
     }
+    .search__miss {
+      font-size: 12px;
+      margin-top: 20px;
+    }
   }
 }

--- a/app/assets/stylesheets/modules/header.scss
+++ b/app/assets/stylesheets/modules/header.scss
@@ -7,23 +7,26 @@
   font-family: Arial, Helvetica, sans-serif;
   &__title{
     display: flex;
-    justify-content: space-between;
   &-image{
     width: 135px;
     height: 40px;
     }
-  &-text{
+  form {
     width: 100%;
-    margin-left: 30px;
-    height: 36px;
+    display: flex;
+    #search{
+      width: 100%;
+      margin-left: 40px;
+      padding: 0 10px;
     }
-  &-search{
+  }
+  &__search{
+    width:40px;
+    height: 40px;
     background-color: $main-color;
-    width: 45px;
-    height: 36px;
     @include header;
     align-items: center;
-    }
+  }
   }
   &__list{
     display: flex;

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,7 +1,8 @@
 class SearchesController < ApplicationController
 
   def index
-    @product = Product.new
+    @products = Product.search(params[:search]).limit(132)
+    @search = params[:search]
   end
 
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -34,4 +34,8 @@ class Product < ApplicationRecord
     Product.order('created_at desc, id desc').where('created_at >= ? and id > ?', created_at, id).reverse.first
   end
 
+  def self.search(search)
+    return Product.all unless search
+    Product.where(['name LIKE ?', "%#{search}%"])
+  end
 end

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -2,9 +2,11 @@
   .header__title
     =link_to root_path do
       = image_tag asset_path("material/logo/logo.png"),class:"header__title-image"
-    %input{type: "text",class:"header__title-text"}
-    .header__title-search
-      %input{type: "image",src:"#{asset_path "material/icon/icon-search 1.png"}",width: "20",height: "20"}
+    .header__form
+    = form_tag(searches_path,method: :get) do
+      = text_field_tag :search, "",placeholder:"何かお探しですか？",class:"form-text"
+      .header__title__search
+        = submit_tag "", :name => nil ,type: "image", src: "#{asset_path "material/icon/icon-search 1.png"}" ,width: "25",height: "25",class: "header__title__search--image"
   .header__list
     %ul.header__list-left
       %li 

--- a/app/views/searches/index.html.haml
+++ b/app/views/searches/index.html.haml
@@ -106,19 +106,28 @@
           完了
 
   .search__content
-    .search__result-head
-      カバン
-      %span.search__result-head-text の検索結果
-    .search__result-number
-      1-100件表示
-    .search__groups
-      .search__group
-        = link_to "#" ,class:"search__group-link" do
-          = image_tag asset_path("material/icon/icon-01.png"), class:"search__group__image"
-          .search__group__text
-            .search__group__text__detail
-              いいね
-          .search__group__price
-            ¥3000    
+    - if @products.present?
+      .search__result-head
+        = @search
+        %span.search__result-head-text の検索結果
+      .search__result-number
+        = "1-#{@products.count}件表示"
+      .search__groups
+        - @products.each do |product|
+          .search__group
+            = link_to product_path(product.id) ,class:"search__group-link" do
+              = image_tag product.images.first.src.url, class:"search__group__image"
+              .search__group__text
+                .search__group__text__detail
+                  = product.name
+              .search__group__price
+                = "¥#{product.price}"
+    - else
+      .search__result-head
+        = @search
+        %span.search__result-head-text の検索結果 
+      .search__miss
+        該当する商品が見つかりません。検索条件を変えて、再度お試しください。   
+
       
 = render partial: "products/footer"


### PR DESCRIPTION
# WHAT
ヘッダーにある検索フォームから商品のあいまい検索ができる機能を実装した。
検索結果によりキーワードに当てはまる物がある時とない時の条件分岐によりビューを変えるようにしている。

# WHY
ユーザーが商品を探す際の利便性が向上するから。

[![Image from Gyazo](https://i.gyazo.com/ac13f57a9a6dc5af4d4c22823e77224c.gif)](https://gyazo.com/ac13f57a9a6dc5af4d4c22823e77224c)
[![Image from Gyazo](https://i.gyazo.com/8fe61d72755b18111cc46c833c8045b9.gif)](https://gyazo.com/8fe61d72755b18111cc46c833c8045b9)