### PR TITLE
トップページの商品一覧表示、税込み価格修正

### DIFF
--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -107,8 +107,7 @@
               %p= product.name
             .category__text__space__price
               %p
-                = product.price
-                %span 円
+                = tax_included_price(product.price)
             .category__text__space__tax
               %p (税込)
     .category__title
@@ -126,8 +125,7 @@
               %p= product.name
             .category__text__space__price
               %p
-                = product.price
-                %span 円
+                = tax_included_price(product.price)
             .category__text__space__tax
               %p (税込)
 


### PR DESCRIPTION
# What
- トップページの商品一覧が、税込み価格に修正

# Why
- 値段が違うと詐欺になってしまうから

[![Image from Gyazo](https://i.gyazo.com/a59d23b51a194aeba5bb484d682b0122.jpg)](https://gyazo.com/a59d23b51a194aeba5bb484d682b0122)