### PR TITLE
購入完了画面のビュー崩れ修正&商品説明欄の修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,7 @@
 @import "modules/index";
 @import "./modules/products";
 @import "./modules/purchase";
+@import "./modules/purchase-done";
 
 @import "modules/edit";
 

--- a/app/assets/stylesheets/modules/_purchase-done.scss
+++ b/app/assets/stylesheets/modules/_purchase-done.scss
@@ -1,0 +1,17 @@
+.purchase-done {
+  width: 700px;
+  height: calc(100vh - 346px);
+  margin: 0 auto;
+  padding-top: 48px;
+  text-align: center;
+  &__back {
+    color: $main-color;
+    text-decoration: none;
+    display: block;
+    text-align: center;
+    margin-bottom: 16px;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_purchase.scss
+++ b/app/assets/stylesheets/modules/_purchase.scss
@@ -206,21 +206,3 @@
     padding-bottom: 40px;
   }  
 }
-
-.purchase-done {
-  width: 700px;
-  margin: 0 auto;
-  h2 {
-    text-align: center;
-  }
-  a {
-    color: $main-color;
-    text-decoration: none;
-    display: block;
-    text-align: center;
-    margin-bottom: 16px;
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -56,7 +56,7 @@
 
     .product-show__content__explanation
       %p
-        = @product.content
+        = simple_format(@product.content)
 
     .product-show__content__info
       %table.product-show__content__info__table

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -3,6 +3,6 @@
 .purchase-done
   %h2 購入が完了しました！
   %h2 ありがとうございます！！
-  = link_to "ユーザーマイページに戻る", user_path(current_user.id)
+  = link_to "ユーザーマイページに戻る", user_path(current_user.id), class: "purchase-done__back"
 
 = render partial: "products/footer_sub"


### PR DESCRIPTION
# What
- 購入完了画面の修正
- 商品詳細ページの説明で改行が反映されるように修正

# Why
- ビュー崩れ修正のため
- 商品説明を見やすくするため
<img width="642" alt="purchase done" src="https://user-images.githubusercontent.com/61184424/85256885-e1d73a80-b49f-11ea-9201-6c5bba16f1f0.png">
<img width="641" alt="product explanation" src="https://user-images.githubusercontent.com/61184424/85257135-4e523980-b4a0-11ea-866a-a2a86462a981.png">
