### PR TITLE
パンくず機能の更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,4 @@ gem 'ancestry'
 gem 'fog-aws'
 gem 'rails-i18n'
 gem 'ransack'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -383,6 +385,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-sass (~> 5.13.0)
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@
 
 @import "modules/header";
 @import "modules/footer";
+@import "modules/breadcrumbs";
 
 @import "modules/index";
 @import "./modules/products";

--- a/app/assets/stylesheets/modules/_breadcrumbs.scss
+++ b/app/assets/stylesheets/modules/_breadcrumbs.scss
@@ -1,0 +1,17 @@
+.breadcrumbs {
+  width: 100%;
+  height: 56px;
+  line-height: 56px;
+  border-top: 1px solid #eee;
+  padding: 0 120px;
+  background-color: #fff;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, .16);
+  font-size: 0.9rem;
+  > a {
+    text-decoration: none;
+    color: #000;
+    &:hover {
+      color: $main-color;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_category.scss
+++ b/app/assets/stylesheets/modules/_category.scss
@@ -1,30 +1,3 @@
-.categories-breadcrumb {
-  width: 100%;
-  height: 56px;
-  line-height: 56px;
-  border-top: 1px solid #eee;
-  padding: 0 120px;
-  background-color: #fff;
-  box-shadow: 0 3px 3px rgba(0, 0, 0, .16);
-  &__list {
-    display: flex;
-    li {
-      font-size: 0.9rem;
-      margin: 0 6px;
-      a {
-        color: #000;
-        text-decoration: none;
-        &:hover {
-          color: $main-color;
-        }
-      }
-    }
-    &--this {
-      font-weight: bold;
-    }
-  }
-}
-
 .categories {
   width: 700px;
   height: 100%;

--- a/app/assets/stylesheets/modules/_product-show.scss
+++ b/app/assets/stylesheets/modules/_product-show.scss
@@ -20,6 +20,7 @@
       }
     }
     &--this {
+      font-size: 0.9rem;
       font-weight: bold;
     }
   }

--- a/app/assets/stylesheets/modules/_product-show.scss
+++ b/app/assets/stylesheets/modules/_product-show.scss
@@ -10,7 +10,7 @@
     display: flex;
     &__item {
       font-size: 0.9rem;
-      margin: 0 6px;
+      margin: 0 4px;
       &__link {
         color: #000;
         text-decoration: none;
@@ -22,6 +22,7 @@
     &--this {
       font-size: 0.9rem;
       font-weight: bold;
+      margin-left: 4px;
     }
   }
 }

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,14 +1,6 @@
 = render partial: "products/header"
-
-.categories-breadcrumb
-  %ul.categories-breadcrumb__list
-    %li
-      = link_to "FURIMA", root_path
-    %li
-      = icon("fa", "angle-right")
-    %li
-      = link_to categories_path do
-        カテゴリ一覧
+- breadcrumb :category
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 
 .categories
   .categories__top

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs__list"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -5,22 +5,22 @@
     %li.product-breadcrumb__list__item
       = link_to "FURIMA", root_path, class: "product-breadcrumb__list__item__link"
     %li.product-breadcrumb__list__item
-      = icon("fa", "angle-right")
+      %span &rsaquo;
     %li.product-breadcrumb__list__item
       = link_to categories_path(anchor: "#{@product.category.parent.parent.name}"), class: "product-breadcrumb__list__item__link" do
         = @product.category.parent.parent.name
     %li.product-breadcrumb__list__item
-      = icon("fa", "angle-right")
+      %span &rsaquo;
     %li.product-breadcrumb__list__item
       = link_to categories_path(anchor: "#{@product.category.parent.parent.name}"), class: "product-breadcrumb__list__item__link" do
         = @product.category.parent.name
     %li.product-breadcrumb__list__item
-      = icon("fa", "angle-right")
+      %span &rsaquo;
     %li.product-breadcrumb__list__item
       = link_to categories_path(anchor: "#{@product.category.parent.parent.name}"), class: "product-breadcrumb__list__item__link" do
         = @product.category.name
     %li.product-breadcrumb__list__item
-      = icon("fa", "angle-right")
+      %span &rsaquo;
     %li.product-breadcrumb__list--this
       = @product.name
 

--- a/app/views/searches/detail_search.html.haml
+++ b/app/views/searches/detail_search.html.haml
@@ -1,4 +1,6 @@
 = render partial: "products/header"
+- breadcrumb :searches
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 
 .search__container
   = render partial: "searches/side"

--- a/app/views/searches/index.html.haml
+++ b/app/views/searches/index.html.haml
@@ -1,4 +1,6 @@
 = render partial: "products/header"
+- breadcrumb :searches
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 
 .search__container
   = render partial: "searches/side"

--- a/app/views/users/address.html.haml
+++ b/app/views/users/address.html.haml
@@ -1,4 +1,6 @@
 = render partial: "products/header"
+- breadcrumb :user_address
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 
 .user-show
   = render partial: 'user-show__side'

--- a/app/views/users/credit.html.haml
+++ b/app/views/users/credit.html.haml
@@ -1,4 +1,6 @@
 = render partial: "products/header"
+- breadcrumb :user_credit
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 
 .user-show
   = render partial: 'user-show__side'

--- a/app/views/users/info.html.haml
+++ b/app/views/users/info.html.haml
@@ -1,4 +1,6 @@
 = render partial: "products/header"
+- breadcrumb :user_info
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 
 .user-show
   = render partial: 'user-show__side'

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,4 +1,6 @@
 = render partial: "products/header"
+- breadcrumb :user_logout
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 
 .user-show
   = render partial: 'user-show__side'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,4 +1,6 @@
 = render partial: "products/header"
+- breadcrumb :user_show
+= breadcrumbs pretext: "",separator: " &rsaquo; "
 
 .user-show
   = render partial: 'user-show__side'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,32 @@
+crumb :root do
+  link "FURIMA", root_path
+end
+
+crumb :category do
+  link "カテゴリー一覧", categories_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -6,27 +6,30 @@ crumb :category do
   link "カテゴリー一覧", categories_path
 end
 
-# crumb :projects do
-#   link "Projects", projects_path
-# end
+crumb :user_show do
+  link "マイページ", user_path
+end
 
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
+crumb :user_info do
+  link "会員情報編集", info_user_path
+  parent :user_show
+end
 
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
+crumb :user_address do
+  link "お届け先情報編集", address_user_path
+  parent :user_show
+end
 
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
+crumb :user_logout do
+  link "ログアウト", address_user_path
+  parent :user_show
+end
 
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).
+crumb :user_credit do
+  link "お支払い情報", credit_user_path
+  parent :user_show
+end
+
+crumb :searches do
+  link "商品検索", searches_path
+end


### PR DESCRIPTION
# What
#### gem 'gretel'を使用し、パンくず機能を更新
- トップページとヘッダーが共通の全ページにパンくず機能を実装
- 商品投稿・購入確認画面などサブヘッダー使用のページには未実装
- 商品詳細ページはgemの仕様に置き換えると複雑になるため、現状維持

# Why
ユーザが現在位置を把握しやすくするため。

<img width="641" alt="search breadcrumb" src="https://user-images.githubusercontent.com/61184424/85271419-bfe8b280-b4b5-11ea-9423-fc5abbf5f3e0.png">
<img width="641" alt="credit breadcrumb" src="https://user-images.githubusercontent.com/61184424/85271450-c8d98400-b4b5-11ea-926d-defb740b764a.png">